### PR TITLE
change user_id fk to unsignedInteger

### DIFF
--- a/database/migrations/create_user_terms_table.php.stub
+++ b/database/migrations/create_user_terms_table.php.stub
@@ -14,7 +14,7 @@ class CreateUserTermsTable extends Migration
     public function up()
     {
         Schema::create('user_terms', function (Blueprint $table) {
-            $table->bigInteger('user_id')->unsigned();
+            $table->unsignedInteger('user_id')->unsigned();
             $table->foreign('user_id')->references('id')->on('users')->onUpdate('cascade')->onDelete('cascade');
 
             $table->bigInteger('term_id')->unsigned();


### PR DESCRIPTION
Hi, I had an issue when I tried to migrate, I found that user default type does not match with the bigInteger so I changed the type, I think it might due to the mysql engine

 SQLSTATE[HY000]: General error: 1215 Cannot add foreign key constraint (SQL: alter table `user_terms` add constraint `user_terms_user_id_foreign` foreign key (`user_id`) references  
   `users` (`id`) on delete cascade on update cascade)  

This should fix it